### PR TITLE
fix: remove invalid attribute of Image component

### DIFF
--- a/temp/ts/template/src/pages/index/index.tsx
+++ b/temp/ts/template/src/pages/index/index.tsx
@@ -9,7 +9,6 @@ export default () => {
         <Image
           src="https://gw.alipayobjects.com/mdn/rms_b5fcc5/afts/img/A*OGyZSI087zkAAAAAAAAAAABkARQnAQ"
           className={styles.logo}
-          alt="logo"
         />
         <View className={styles.text}>
           编辑 <Text className={styles.path}>src/pages/index/index.js</Text>{' '}


### PR DESCRIPTION
Typescript detected that alt is an invalid attribute for the Image component. I checked the WeChat development documentation and found that there is indeed no alt attribute.